### PR TITLE
feat: Allow passing a falsy index to disable indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ Expected `opts` include:
   [random-access-storage](https://github.com/random-access-storage) instance to
   its callback `cb`
 
+If `index` is falsy, the default indexes will not be created. You can still
+create indexes in userland with the `osm.core.use` function.
+
 ### osm.create(element, cb)
 
 Create the new OSM element `element` and add it to the database. The resulting

--- a/test/lib/create-db.js
+++ b/test/lib/create-db.js
@@ -8,12 +8,13 @@ var path = require('path')
 module.exports = createOne
 module.exports.two = createTwo
 
-function createOne () {
+function createOne (opts) {
+  const index = opts && opts.index
   var core = kappa(ram, { valueEncoding: 'json' })
   var dir = path.join(tmp, 'kappa-osm-' + String(Math.random()).substring(10))
   return Osm({
     core: core,
-    index: level(dir),
+    index: index || level(dir),
     storage: function (name, cb) { cb(null, ram()) }
   })
 }

--- a/test/no-index.js
+++ b/test/no-index.js
@@ -1,0 +1,41 @@
+var test = require('tape')
+var createDb = require('./lib/create-db')
+
+test('create nodes', function (t) {
+  var db = createDb({ index: null })
+  t.plan(2)
+
+  var nodes = [
+    {
+      type: 'node',
+      changeset: '9',
+      lat: '-11',
+      lon: '-10',
+      timestamp: '2017-10-10T19:55:08.570Z'
+    },
+    {
+      type: 'node',
+      changeset: '9',
+      lat: '-11',
+      lon: '-10'
+    }
+  ]
+
+  var batch = nodes.map(function (node) {
+    return {
+      type: 'put',
+      value: node
+    }
+  })
+
+  db.batch(batch, function (err, elms) {
+    t.error(err)
+    elms.forEach(clearIdVersion)
+    t.deepEquals(elms, nodes)
+  })
+})
+function clearIdVersion (elm) {
+  delete elm.id
+  delete elm.version
+  delete elm.deviceId
+}


### PR DESCRIPTION
Added a simple test and updated the README. 

I wonder if this will cause any issues with upstream modules depending on `osm.index` to be an instance of levelup? Wondering if there are any places that would be a known issue..