### PR TITLE
feat: Add authorId to elements. Fixes mapeo-core#102

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ created node with id 58261217205dc19b
     changeset: 'abcdef' },
     version: '366212350b5996f944df9df25e679a98545bdac98f507a06f493d167ff9d5f14@0',
     links: [],
-    deviceId: '366212350b5996f944df9df25e679a98545bdac98f507a06f493d167ff9d5f14'
+    deviceId: '366212350b5996f944df9df25e679a98545bdac98f507a06f493d167ff9d5f14',
+    authorId: '366212350b5996f944df9df25e679a98545bdac98f507a06f493d167ff9d5f14'
   }
 ]
 ```
@@ -89,8 +90,11 @@ Expected `opts` include:
 ### osm.create(element, cb)
 
 Create the new OSM element `element` and add it to the database. The resulting
-element, populated with the `id`, `version`, and `deviceId` fields, is returned
+element, populated with the `id`, `version`, and `authorId`, and `deviceId` fields, is returned
 by the callback `cb`.
+
+`authorId` is the original author's deviceId, while `deviceId` represents the device
+that most recently edited the element.
 
 ### osm.get(id, cb)
 
@@ -275,9 +279,13 @@ Documents (OSM elements, observations, etc) have a common format:
     changeset: String,
     links: Array<String>,
     version: String,
-    deviceId: String
+    deviceId: String,
+    authorId: String
   }
 ```
+
+*Note: `authorId` is the original author's deviceId, while `deviceId` represents the device
+that most recently edited the element.*
 
 **TODO**: talk about forking data & forking architecture*
 

--- a/index.js
+++ b/index.js
@@ -81,10 +81,7 @@ Osm.prototype.create = function (element, cb) {
 }
 
 Osm.prototype._getAuthor = function (id, cb) {
-  this.core.api.author.get(id, function (err, authorId) {
-    if (err) return cb(err)
-    return cb(null, authorId)
-  })
+  this.core.api.author.get(id, cb)
 }
 
 // OsmId -> [OsmElement]

--- a/index.js
+++ b/index.js
@@ -135,7 +135,6 @@ Osm.prototype.getByVersion = function (version, opts, cb) {
   this._getByVersion(version, function (err, doc) {
     if (err) return cb(err)
     if (!doc) return cb(null, null)
-    console.log(doc.id)
     self._getAuthor(doc.id, function (err, authorId) {
       if (err) return cb(err)
       doc = Object.assign({}, doc, {

--- a/lib/author-index.js
+++ b/lib/author-index.js
@@ -1,0 +1,35 @@
+var view = require('kappa-view')
+
+function createIndex (lvl) {
+  return view(lvl, function (db) {
+    return {
+      maxBatch: 100,
+      map: function (nodes, next) {
+        var ops = nodes
+          .filter(function (node) {
+            return !node.value.links.length
+          })
+          .reduce(function (accum, node) {
+            var authorId = node.key.toString('hex')
+            accum.push({
+              type: 'put',
+              key: node.value.id,
+              value: authorId
+            })
+            return accum
+          }, [])
+        db.batch(ops, next)
+      },
+      api: {
+        get: function (core, id, cb) {
+          db.get(id, function (err, authorId) {
+            if (err && err.notFound) cb(null, null)
+            else cb(err, authorId)
+          })
+        }
+      }
+    }
+  })
+}
+
+module.exports = createIndex

--- a/test/author.js
+++ b/test/author.js
@@ -1,7 +1,7 @@
 var test = require('tape')
 var createDb = require('./lib/create-db')
 var setup = require('./lib/setup')
-var pump = require('pump')
+var replicate = require('./lib/replicate')
 
 test('original entry has authorId set', function (t) {
   t.plan(4)
@@ -175,23 +175,6 @@ test('edit performed by a different author', function (t) {
     }
   })
 })
-
-// TODO: create utility function + share across tests
-function replicate (osm0, osm1, cb) {
-  osm0.ready(() => {
-    osm1.ready(onready)
-  })
-  function onready () {
-    var r0 = osm0.replicate(true)
-    var r1 = osm1.replicate(false)
-    pump(r0, r1, r0, err => {
-      if (err) return cb(err)
-      osm0.ready(() => {
-        osm1.ready(cb)
-      })
-    })
-  }
-}
 
 // Write multiple batches of batch writes.
 // So, Array<Array<WriteOp>>

--- a/test/author.js
+++ b/test/author.js
@@ -1,8 +1,11 @@
 var test = require('tape')
 var createDb = require('./lib/create-db')
+var setup = require('./lib/setup')
+var pump = require('pump')
 
-test('get history by id', function (t) {
-  t.plan(10)
+test('original entry has authorId set', function (t) {
+  t.plan(4)
+
   var db = createDb()
   var batches = [
     [
@@ -15,15 +18,36 @@ test('get history by id', function (t) {
           lon: '4',
           timestamp: '2018-09-01T00:00:00.000Z'
         }
-      },
+      }
+    ]
+  ]
+
+  batchesWrite(db, batches, (err, res) => {
+    t.error(err, 'batch writes ok')
+
+    db.get('A', (err, elms) => {
+      t.error(err, 'got element ok')
+      t.equals(elms.length, 1, 'one result')
+      const elm = elms[0]
+      t.deepEquals(elm.deviceId, elm.authorId, 'authorId and deviceId are the same')
+    })
+  })
+})
+
+test('first edit with same authorId', function (t) {
+  t.plan(4)
+
+  var db = createDb()
+  var batches = [
+    [
       {
         type: 'put',
-        id: 'B',
+        id: 'A',
         value: {
           type: 'node',
-          lat: '1',
-          lon: '2',
-          timestamp: '2017-12-01T00:00:00.000Z'
+          lat: '3',
+          lon: '4',
+          timestamp: '2018-09-01T00:00:00.000Z'
         }
       }
     ],
@@ -33,70 +57,153 @@ test('get history by id', function (t) {
         id: 'A',
         value: {
           type: 'node',
-          lat: '3.3',
-          lon: '4.4',
-          timestamp: '2018-09-01T01:00:00.000Z'
-        }
-      }
-    ],
-    [
-      {
-        type: 'put',
-        id: 'A',
-        value: {
-          type: 'node',
-          lat: '3.33',
-          lon: '4.44',
-          timestamp: '2018-09-01T02:00:00.000Z'
-        }
-      },
-      {
-        type: 'put',
-        id: 'B',
-        value: {
-          type: 'node',
-          lat: '1.11',
-          lon: '2.22',
-          timestamp: '2017-12-01T01:00:00.000Z'
-        }
-      }
-    ],
-    [ // this one is first, testing for out of order:
-      {
-        type: 'put',
-        id: 'A',
-        value: {
-          type: 'node',
-          lat: '3.01',
-          lon: '4.01',
-          timestamp: '2017-09-01T00:00:00.000Z'
+          lat: '4',
+          lon: '5',
+          timestamp: '2018-09-02T00:00:00.000Z'
         }
       }
     ]
   ]
+
+  batchesWrite(db, batches, (err, res) => {
+    t.error(err, 'batch writes ok')
+
+    db.get('A', (err, elms) => {
+      t.error(err, 'got element ok')
+      t.equals(elms.length, 1, 'one result')
+      const elm = elms[0]
+      t.deepEquals(elm.deviceId, elm.authorId, 'authorId and deviceId are the same')
+    })
+  })
+})
+
+test('edit performed by a different author', function (t) {
+  t.plan(20)
+
+  const batch0 = [
+    {
+      type: 'put',
+      id: 'A',
+      value: {
+        type: 'node',
+        lat: '3',
+        lon: '4',
+        timestamp: '2018-09-01T00:00:00.000Z'
+      }
+    },
+    {
+      type: 'put',
+      id: 'B',
+      value: {
+        type: 'node',
+        lat: '3',
+        lon: '4',
+        timestamp: '2018-09-01T00:00:00.000Z'
+      }
+    }
+  ]
+  const batch1 = [
+    {
+      type: 'put',
+      id: 'A',
+      value: {
+        type: 'node',
+        lat: '4',
+        lon: '5',
+        timestamp: '2018-10-01T00:00:00.000Z'
+      }
+    },
+    {
+      type: 'put',
+      id: 'B',
+      value: {
+        type: 'node',
+        lat: '4',
+        lon: '5',
+        timestamp: '2018-10-01T00:00:00.000Z'
+      }
+    }
+  ]
+
+  createDb.two(function (osm0, osm1) {
+    const key0 = osm0.core.feeds()[0].key.toString('hex')
+    const key1 = osm1.core.feeds()[0].key.toString('hex')
+    var versions = {}
+    setup(osm0, batch0, function (err, elms) {
+      t.error(err, 'osm0 setup ok')
+      replicate(osm0, osm1, err => {
+        t.error(err, 'sync ok')
+        setup(osm1, batch1, function (err, elms) {
+          t.error(err, 'osm1 setup ok')
+          replicate(osm0, osm1, err => {
+            t.error(err, 'sync ok')
+            check()
+          })
+        })
+      })
+    })
+
+    function check () {
+      osm0.get('A', (err, elms) => {
+        t.error(err, 'got elements ok')
+        t.equals(elms.length, 1, 'one result')
+        const elm = elms[0]
+        t.deepEquals(elm.deviceId, key1, 'deviceId ok')
+        t.deepEquals(elm.authorId, key0, 'authorId ok')
+      })
+      osm1.get('A', (err, elms) => {
+        t.error(err, 'got elements ok')
+        t.equals(elms.length, 1, 'one result')
+        const elm = elms[0]
+        t.deepEquals(elm.deviceId, key1, 'deviceId ok')
+        t.deepEquals(elm.authorId, key0, 'authorId ok')
+      })
+      osm0.get('B', (err, elms) => {
+        t.error(err, 'got elements ok')
+        t.equals(elms.length, 1, 'one result')
+        const elm = elms[0]
+        t.deepEquals(elm.deviceId, key1, 'deviceId ok')
+        t.deepEquals(elm.authorId, key0, 'authorId ok')
+      })
+      osm1.get('B', (err, elms) => {
+        t.error(err, 'got elements ok')
+        t.equals(elms.length, 1, 'one result')
+        const elm = elms[0]
+        t.deepEquals(elm.deviceId, key1, 'deviceId ok')
+        t.deepEquals(elm.authorId, key0, 'authorId ok')
+      })
+    }
+  })
+})
+
+// TODO: create utility function + share across tests
+function replicate (osm0, osm1, cb) {
+  osm0.ready(() => {
+    osm1.ready(onready)
+  })
+  function onready () {
+    var r0 = osm0.replicate(true)
+    var r1 = osm1.replicate(false)
+    pump(r0, r1, r0, err => {
+      if (err) return cb(err)
+      osm0.ready(() => {
+        osm1.ready(cb)
+      })
+    })
+  }
+}
+
+// Write multiple batches of batch writes.
+// So, Array<Array<WriteOp>>
+function batchesWrite (db, batches, cb) {
   var results = []
   ;(function next (i) {
     var batch = batches[i]
-    if (!batch) return check()
+    if (!batch) return cb(null, results)
     db.batch(batch, function (err, res) {
-      t.error(err)
+      if (err) return cb(err)
       results.push(res)
       next(i + 1)
     })
   })(0)
-
-  function check () {
-    db._getAuthor('A', function (err, deviceId) {
-      t.error(err)
-      t.deepEqual(deviceId, results[2][0].deviceId)
-    })
-    db._getAuthor('B', function (err, deviceId) {
-      t.error(err)
-      t.deepEqual(deviceId, results[2][1].deviceId)
-    })
-    db._getAuthor('C', function (err, deviceId) {
-      t.error(err)
-      t.deepEqual(deviceId, null)
-    })
-  }
-})
+}

--- a/test/author.js
+++ b/test/author.js
@@ -1,0 +1,102 @@
+var test = require('tape')
+var createDb = require('./lib/create-db')
+
+test('get history by id', function (t) {
+  t.plan(10)
+  var db = createDb()
+  var batches = [
+    [
+      {
+        type: 'put',
+        id: 'A',
+        value: {
+          type: 'node',
+          lat: '3',
+          lon: '4',
+          timestamp: '2018-09-01T00:00:00.000Z'
+        }
+      },
+      {
+        type: 'put',
+        id: 'B',
+        value: {
+          type: 'node',
+          lat: '1',
+          lon: '2',
+          timestamp: '2017-12-01T00:00:00.000Z'
+        }
+      }
+    ],
+    [
+      {
+        type: 'put',
+        id: 'A',
+        value: {
+          type: 'node',
+          lat: '3.3',
+          lon: '4.4',
+          timestamp: '2018-09-01T01:00:00.000Z'
+        }
+      }
+    ],
+    [
+      {
+        type: 'put',
+        id: 'A',
+        value: {
+          type: 'node',
+          lat: '3.33',
+          lon: '4.44',
+          timestamp: '2018-09-01T02:00:00.000Z'
+        }
+      },
+      {
+        type: 'put',
+        id: 'B',
+        value: {
+          type: 'node',
+          lat: '1.11',
+          lon: '2.22',
+          timestamp: '2017-12-01T01:00:00.000Z'
+        }
+      }
+    ],
+    [ // this one is first, testing for out of order:
+      {
+        type: 'put',
+        id: 'A',
+        value: {
+          type: 'node',
+          lat: '3.01',
+          lon: '4.01',
+          timestamp: '2017-09-01T00:00:00.000Z'
+        }
+      }
+    ]
+  ]
+  var results = []
+  ;(function next (i) {
+    var batch = batches[i]
+    if (!batch) return check()
+    db.batch(batch, function (err, res) {
+      t.error(err)
+      results.push(res)
+      next(i + 1)
+    })
+  })(0)
+
+  function check () {
+    db._getAuthor('A', function (err, deviceId) {
+      t.error(err)
+      t.deepEqual(deviceId, results[2][0].deviceId)
+    })
+    db._getAuthor('B', function (err, deviceId) {
+      t.error(err)
+      t.deepEqual(deviceId, results[2][1].deviceId)
+    })
+    db._getAuthor('C', function (err, deviceId) {
+      t.error(err)
+      t.deepEqual(deviceId, null)
+    })
+  }
+})

--- a/test/batch.js
+++ b/test/batch.js
@@ -146,6 +146,7 @@ test('create + delete nodes', function (t) {
         t.notEqual(elms[0].version, elmVersion)
         delete elms[0].version
         delete elms[0].deviceId
+        delete elms[0].authorId
         t.deepEquals(elms[0], { id: elmId, deleted: true, changeset: '10', links: [elmVersion] })
       })
     })

--- a/test/del.js
+++ b/test/del.js
@@ -27,6 +27,7 @@ test('delete', function (t) {
             type: 'node',
             id: elm.id,
             deviceId: elms[0].deviceId,
+            authorId: elms[0].authorId,
             version: elms[0].version,
             links: [elm.version]
           }

--- a/test/history.js
+++ b/test/history.js
@@ -41,6 +41,7 @@ test('get all docs ordered by date', function (t) {
     t.error(err)
     collect(db.history(), function (err, docs) {
       t.error(err)
+      deleteAuthors(docs)
       t.deepEqual(docs, [
         {
           type: 'node',
@@ -125,6 +126,7 @@ test('get all docs by type ordered by date', function (t) {
     t.error(err)
     collect(db.history({ type: 'node' }), function (err, docs) {
       t.error(err)
+      deleteAuthors(docs)
       t.deepEqual(docs, [
         {
           type: 'node',
@@ -160,6 +162,7 @@ test('get all docs by type ordered by date', function (t) {
     })
     collect(db.history({ type: 'way' }), function (err, docs) {
       t.error(err)
+      deleteAuthors(docs)
       t.deepEqual(docs, [
         {
           type: 'way',
@@ -211,6 +214,7 @@ test('observation history', function (t) {
     t.error(err)
     collect(db.history({ type: 'observation' }), function (err, docs) {
       t.error(err)
+      deleteAuthors(docs)
       t.deepEqual(docs, [
         {
           type: 'observation',
@@ -279,6 +283,7 @@ test('reverse observation history', function (t) {
     t.error(err)
     collect(db.history({ type: 'observation', reverse: true }), function (err, docs) {
       t.error(err)
+      deleteAuthors(docs)
       t.deepEqual(docs, [
         {
           type: 'observation',
@@ -397,6 +402,7 @@ test('get history by id', function (t) {
   function check () {
     collect(db.history({ id: 'A' }), function (err, docs) {
       t.error(err)
+      deleteAuthors(docs)
       t.deepEqual(docs, [
         {
           type: 'node',
@@ -442,6 +448,7 @@ test('get history by id', function (t) {
     })
     collect(db.history({ id: 'B' }), function (err, docs) {
       t.error(err)
+      deleteAuthors(docs)
       t.deepEqual(docs, [
         {
           type: 'node',
@@ -494,3 +501,10 @@ test('exclusive id and type history sorting options', function (t) {
     })
   })
 })
+
+function deleteAuthors (docs) {
+  for (var i in docs) {
+    var doc = docs[i]
+    delete doc.authorId
+  }
+}

--- a/test/lib/replicate.js
+++ b/test/lib/replicate.js
@@ -1,0 +1,20 @@
+var pump = require('pump')
+
+module.exports = replicate
+
+function replicate (osm0, osm1, cb) {
+  osm0.ready(() => {
+    osm1.ready(onready)
+  })
+  function onready () {
+    var r0 = osm0.replicate(true)
+    var r1 = osm1.replicate(false)
+    pump(r0, r1, r0, err => {
+      if (err) return cb(err)
+      osm0.ready(() => {
+        osm1.ready(cb)
+      })
+    })
+  }
+}
+

--- a/test/put.js
+++ b/test/put.js
@@ -189,6 +189,7 @@ test('soft delete a node', function (t) {
         delete elms[0].version
         delete elms[0].deviceId
         delete elms[0].timestamp
+        delete elms[0].authorId
         t.deepEquals(elms[0].links, [elm.version])
         delete elms[0].links
         t.deepEquals(elms[0], nodeDeletion)


### PR DESCRIPTION
This adds an `author` index which is a simple key value index for any element that has no links.

Fixes https://github.com/digidem/mapeo-core/issues/102

This probably could use another test that uses multiple databases and replicates them.

Should we rename deviceId to something else more descriptive? 