### PR TITLE
fix: Not mutating ops in batch operation

### DIFF
--- a/index.js
+++ b/index.js
@@ -274,6 +274,7 @@ Osm.prototype.batch = function (ops, cb) {
   if (!ops || !ops.length) return cb()
 
   var self = this
+  var mutOps = ops
   cb = once(cb)
 
   populateWayRelationRefs(function (err) {
@@ -288,10 +289,10 @@ Osm.prototype.batch = function (ops, cb) {
   function populateWayRelationRefs (cb) {
     var pending = 0
     var error
-    for (var i = 0; i < ops.length; i++) {
-      if (ops[i].type === 'del') {
+    for (var i = 0; i < mutOps.length; i++) {
+      if (mutOps[i].type === 'del') {
         pending++
-        updateRefs(ops[i].id, ops[i].value.links || [], ops[i].value, function (err) {
+        updateRefs(mutOps[i].id, mutOps[i].value.links || [], mutOps[i].value, function (err) {
           if (err) error = err
           if (!--pending) cb(error)
         })
@@ -302,25 +303,25 @@ Osm.prototype.batch = function (ops, cb) {
 
   function populateMissingLinks (cb) {
     var pending = 1
-    for (var i = 0; i < ops.length; i++) {
-      if (!ops[i].id) {
-        ops[i].id = utils.generateId()
-        ops[i].value.links = []
-      } else if (!ops[i].value.links) {
+    for (var i = 0; i < mutOps.length; i++) {
+      if (!mutOps[i].id) {
+        mutOps[i].id = utils.generateId()
+        mutOps[i].value.links = []
+      } else if (!mutOps[i].value.links) {
         pending++
         ;(function get (op) {
           self.core.api.kv.get(op.id, function (err, versions) {
             op.value.links = versions || []
             if (!--pending) cb(err)
           })
-        })(ops[i])
+        })(mutOps[i])
       }
     }
     if (!--pending) cb()
   }
 
   function writeData (cb) {
-    var batch = ops.map(osmOpToMsg)
+    var batch = mutOps.map(osmOpToMsg)
 
     self._ready(function () {
       var key = self.writer.key.toString('hex')

--- a/index.js
+++ b/index.js
@@ -274,7 +274,7 @@ Osm.prototype.batch = function (ops, cb) {
   if (!ops || !ops.length) return cb()
 
   var self = this
-  var mutOps = ops
+  var mutOps = utils.deepClone(ops)
   cb = once(cb)
 
   populateWayRelationRefs(function (err) {

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var uniq = require('uniq')
 var EventEmitter = require('events').EventEmitter
 var through = require('through2')
 var pumpify = require('pumpify')
+var clone = require('clone')
 
 var umkv = require('unordered-materialized-kv')
 var checkElement = require('./lib/check-element')
@@ -274,7 +275,7 @@ Osm.prototype.batch = function (ops, cb) {
   if (!ops || !ops.length) return cb()
 
   var self = this
-  var mutOps = utils.deepClone(ops)
+  var mutOps = clone(ops)
   cb = once(cb)
 
   populateWayRelationRefs(function (err) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,7 +11,8 @@ module.exports = {
   nodeToVersion: nodeToVersion,
   versionFromKeySeq: versionFromKeySeq,
   hyperDbKeyToId: hyperDbKeyToId,
-  getPreviousHeads: getPreviousHeads
+  getPreviousHeads: getPreviousHeads,
+  deepClone: deepClone
 }
 
 // [[minLat,maxLat],[minLon,maxLon]] -> Error? [Mutate]
@@ -149,4 +150,20 @@ function headsToVersion (heads) {
   }
 
   return Buffer.concat(bufAccum)
+}
+
+// From: https://stackoverflow.com/questions/4459928/how-to-deep-clone-in-javascript/
+function deepClone(aObject) {
+  if (!aObject) {
+    return aObject;
+  }
+
+  let v;
+  let bObject = Array.isArray(aObject) ? [] : {};
+  for (const k in aObject) {
+    v = aObject[k];
+    bObject[k] = (typeof v === "object") ? deepClone(v) : v;
+  }
+
+  return bObject;
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,8 +11,7 @@ module.exports = {
   nodeToVersion: nodeToVersion,
   versionFromKeySeq: versionFromKeySeq,
   hyperDbKeyToId: hyperDbKeyToId,
-  getPreviousHeads: getPreviousHeads,
-  deepClone: deepClone
+  getPreviousHeads: getPreviousHeads
 }
 
 // [[minLat,maxLat],[minLon,maxLon]] -> Error? [Mutate]
@@ -150,20 +149,4 @@ function headsToVersion (heads) {
   }
 
   return Buffer.concat(bufAccum)
-}
-
-// From: https://stackoverflow.com/questions/4459928/how-to-deep-clone-in-javascript/
-function deepClone(aObject) {
-  if (!aObject) {
-    return aObject;
-  }
-
-  let v;
-  let bObject = Array.isArray(aObject) ? [] : {};
-  for (const k in aObject) {
-    v = aObject[k];
-    bObject[k] = (typeof v === "object") ? deepClone(v) : v;
-  }
-
-  return bObject;
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "kappa"
   ],
   "dependencies": {
+    "clone": "^2.1.2",
     "collect-stream": "^1.2.1",
     "d64": "^1.0.0",
     "duplexify": "^4.1.1",

--- a/test/batch.js
+++ b/test/batch.js
@@ -23,6 +23,10 @@ test('create nodes', function (t) {
     }
   ]
 
+  var updatedWithLinks = nodes
+  updatedWithLinks[0].links = []
+  updatedWithLinks[1].links = []
+
   var batch = nodes.map(function (node) {
     return {
       type: 'put',
@@ -35,7 +39,7 @@ test('create nodes', function (t) {
   db.batch(batch, function (err, elms) {
     t.error(err)
     elms.forEach(clearIdVersion)
-    t.deepEquals(elms, nodes)
+    t.deepEquals(elms, updatedWithLinks)
     t.deepEquals(batch, batchClone, 'Batch ops not mutated by batch()')
   })
 })

--- a/test/batch.js
+++ b/test/batch.js
@@ -1,6 +1,7 @@
 var test = require('tape')
 var createDb = require('./lib/create-db')
 var setup = require('./lib/setup')
+var utils = require('../lib/utils')
 
 test('create nodes', function (t) {
   var db = createDb()
@@ -23,7 +24,7 @@ test('create nodes', function (t) {
     }
   ]
 
-  var updatedWithLinks = nodes
+  var updatedWithLinks = utils.deepClone(nodes)
   updatedWithLinks[0].links = []
   updatedWithLinks[1].links = []
 

--- a/test/batch.js
+++ b/test/batch.js
@@ -1,7 +1,7 @@
 var test = require('tape')
 var createDb = require('./lib/create-db')
 var setup = require('./lib/setup')
-var utils = require('../lib/utils')
+var clone = require('clone')
 
 test('create nodes', function (t) {
   var db = createDb()
@@ -24,7 +24,7 @@ test('create nodes', function (t) {
     }
   ]
 
-  var updatedWithLinks = utils.deepClone(nodes)
+  var updatedWithLinks = clone(nodes)
   updatedWithLinks[0].links = []
   updatedWithLinks[1].links = []
 
@@ -34,7 +34,7 @@ test('create nodes', function (t) {
       value: node
     }
   })
-  var batchClone = JSON.parse(JSON.stringify(batch))
+  var batchClone = clone(batch)
   t.deepEquals(batch, batchClone, 'Clone deep equals before batch')
 
   db.batch(batch, function (err, elms) {

--- a/test/batch.js
+++ b/test/batch.js
@@ -5,7 +5,7 @@ var setup = require('./lib/setup')
 test('create nodes', function (t) {
   var db = createDb()
 
-  t.plan(2)
+  t.plan(4)
 
   var nodes = [
     {
@@ -29,11 +29,14 @@ test('create nodes', function (t) {
       value: node
     }
   })
+  var batchClone = JSON.parse(JSON.stringify(batch))
+  t.deepEquals(batch, batchClone, 'Clone deep equals before batch')
 
   db.batch(batch, function (err, elms) {
     t.error(err)
     elms.forEach(clearIdVersion)
     t.deepEquals(elms, nodes)
+    t.deepEquals(batch, batchClone, 'Batch ops not mutated by batch()')
   })
 })
 


### PR DESCRIPTION
A very naive way of not mutating `ops`, cloning it to another object.

Not sure this solves the problem, a bit hard to understand without actually seeing it failing a test.